### PR TITLE
update bolt and leveldb

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 550f7ef7cdcb42ddb76b6ee79a01965bc85fa094fb8b541101365f573d37fa59
-updated: 2017-01-07T14:53:37.425158018-06:00
+updated: 2017-02-02T15:46:37.884119846-06:00
 imports:
 - name: github.com/btcsuitereleases/btcd
   version: e005ff2cdaac3b3a0b60c8d03978221b784ad50a
@@ -29,7 +29,7 @@ imports:
 - name: github.com/FactomProject/basen
   version: fe3947df716ebfda9847eb1b9a48f9592e06478c
 - name: github.com/FactomProject/bolt
-  version: 7d662c5bb27d9defa01fa0563959594bb77ee62b
+  version: 952a1b4e9a55f458d536cf703bce25a4e9c99841
 - name: github.com/FactomProject/btcutil
   version: 43986820ccd50b2b02b83e575cb3a39c87457482
   subpackages:
@@ -50,7 +50,7 @@ imports:
   - state/stateinit
   - wallet
 - name: github.com/FactomProject/factom
-  version: 895ee68fec5b0926a88c6dde75a71a87e2dcdfc7
+  version: ee66cae73edad91fd38befa0d7755c2572f9993a
   subpackages:
   - wallet
   - wallet/wsapi
@@ -59,7 +59,7 @@ imports:
   subpackages:
   - controlpanel
 - name: github.com/FactomProject/factomd
-  version: 65a63b968cee75584e3387c27d33b0e33babcf5d
+  version: 884c281531b4366628dfb693f5ccd4b0dd5f4b7c
   subpackages:
   - anchor
   - common/adminBlock
@@ -71,6 +71,7 @@ imports:
   - common/factoid
   - common/interfaces
   - common/primitives
+  - common/primitives/random
   - database/blockExtractor
   - database/boltdb
   - database/databaseOverlay
@@ -92,7 +93,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/FactomProject/goleveldb
-  version: b882f9c7069c9730b1e7f8dd17250dabcaefa5ba
+  version: 9d147f2b8f767adca2a29f9728658681081b03a8
   subpackages:
   - leveldb
   - leveldb/cache
@@ -109,22 +110,22 @@ imports:
 - name: github.com/FactomProject/netki-go-partner-client
   version: 426acb535e66cc2f9e6226ae254555e3572fd142
 - name: github.com/FactomProject/snappy-go
-  version: fff4c573c694b1e2d5c7a9b2b72dbe947b6a4c8e
+  version: f2f83b22c29e5abc60e3a95062ce1491d3b95371
   subpackages:
   - snappy
 - name: github.com/FactomProject/web
   version: 7daee1bf727fc2cd9142b9a73a797f98b3180756
 - name: golang.org/x/crypto
-  version: c3b1d0d6d8690eaebe3064711b026770cc37efa3
+  version: bed12803fa9663d7aa2c2346b0c634ad2dcd43b7
   subpackages:
   - pbkdf2
   - ripemd160
 - name: golang.org/x/net
-  version: b7883d29650d340156352196ef5e434db117757b
+  version: 007e530097ad7f954752df63046b4036f98ba6a6
   subpackages:
   - websocket
 - name: golang.org/x/sys
-  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  version: 7a6e5648d140666db5d920909e082ca00a87ba2c
   subpackages:
   - unix
 - name: gopkg.in/gcfg.v1


### PR DESCRIPTION
this update allows factom-walletd to use the latest versions of leveldb and bolt.