### PR TITLE
Disable remote connections by default

### DIFF
--- a/factom-walletd.go
+++ b/factom-walletd.go
@@ -52,6 +52,7 @@ func main() {
 		walletdLocation = flag.String("selfaddr", "", "comma seperated IPAddresses and DNS names of this factom-walletd to use when creating a cert file")
 		encryptedDB     = flag.Bool("encrypted", false, "Option to enable encryption for database when not in use.")
 		passphrase      = flag.String("passphrase", "", "Passphrase used to encrypt/decrypt the wallet")
+		remote          = flag.Bool("remote", false, "Allow remote connections to walletd")
 	)
 	flag.Parse()
 
@@ -366,5 +367,12 @@ func main() {
 	}
 
 	// start the wsapi server
-	wsapi.Start(fctWallet, fmt.Sprintf(":%d", port), RPCConfig)
+	bindTo := "127.0.0.1"
+	if *remote {
+		fmt.Printf("Remote connections to this wallet are enabled")
+		bindTo = "0.0.0.0"
+	} else {
+		fmt.Printf("Remote connections to this wallet are disabled")
+	}
+	wsapi.Start(fctWallet, fmt.Sprintf("%s:%d", bindTo, port), RPCConfig)
 }


### PR DESCRIPTION
closes: #79

For security reasons, this prevents connections made outside of localhost by default and the caller has to explicitly enable allowing remote connections.